### PR TITLE
Fix skill sensor state returning stale XP, and accept live xp/level updates

### DIFF
--- a/custom_components/runelite/sensors/osrs_skill.py
+++ b/custom_components/runelite/sensors/osrs_skill.py
@@ -27,7 +27,7 @@ class OsrsSkillSensor(SensorEntity, RestoreEntity):
 
     @property
     def state(self):
-        return self._skill_data['xp']
+        return self._skill_xp
     
     @property
     def device_info(self) -> DeviceInfo:
@@ -67,4 +67,6 @@ class OsrsSkillSensor(SensorEntity, RestoreEntity):
     
     async def update_data(self, data: dict) -> None:
         self._skill_virtual_level = data.get("virtual_level", self._skill_virtual_level)
+        self._skill_xp = data.get("xp", self._skill_xp)
+        self._skill_level = data.get("level", self._skill_level)
         self.async_schedule_update_ha_state()

--- a/custom_components/runelite/services.py
+++ b/custom_components/runelite/services.py
@@ -52,6 +52,8 @@ SET_ENTITY_DATA_SCHEMA = vol.Schema(
         vol.Optional("is_online"): cv.boolean,
         vol.Optional("world"): cv.string,
         vol.Optional("virtual_level"): vol.All(int, vol.Range(min=-100, max=200)),
+        vol.Optional("xp"): vol.All(int, vol.Range(min=0, max=5000000000)),
+        vol.Optional("level"): vol.All(int, vol.Range(min=1, max=200)),
     }
 )
 


### PR DESCRIPTION
Two related changes to `OsrsSkillSensor`, plus the schema change needed to make live updates reach it.

## 1. Bug: skill state is frozen at entity creation

`state` returns `self._skill_data["xp"]` — the dict captured in `__init__` — while `async_update()` writes the refreshed value to `self._skill_xp`:

```python
@property
def state(self):
    return self._skill_data["xp"]      # never written again

async def async_update(self):
    ...
    self._skill_xp = skill.get("xp", self._skill_xp)
```

So a skill sensor's **state stays frozen at whatever XP the player had when the entity was created**, while its `xp` attribute updates correctly on every hiscores refresh. The two silently diverge.

Measured on my own install before the fix:

| | value |
|---|---|
| `sensor.<user>_skill_mining` state | `34855036` |
| same entity, `xp` attribute | `34947778` |

92,742 XP apart — and `skill_total` showed exactly the same delta, since all of it was Mining. It is easy to miss because the two agree immediately after the entity is created; they only drift after the first hiscores poll.

## 2. Allow live xp/level updates from the plugin

- `SET_ENTITY_DATA_SCHEMA` gains optional `xp` and `level`. Without this the service call is rejected by voluptuous with a 400 before it ever reaches the entity, so the values would be dropped at the API boundary.
- `update_data()` applies them, the same way `virtual_level` already is.

This supports live XP from the plugin side — see db1996/homeassistant#3 and the companion PR db1996/homeassistant#4. On its own, without that PR, nothing sends these fields and the change is inert.

## Testing

Running on Home Assistant 2026.8.2. The patched integration loads cleanly, all 25 skill sensors populate, and no errors appear in the log.

Verified end to end with the companion plugin PR built and running: the plugin posts `{"virtual_level":99,"xp":13040513,"entity_id":"sensor.runelite_<user>_skill_fishing"}` and the sensor state reflects it within a second of the XP being gained.

The stale-state fix is separately confirmed — after a `fetch_osrs_highscores`, state and the `xp` attribute now move together. A hiscores refresh is exactly the operation that previously produced the divergence.
